### PR TITLE
Made relevant chnages

### DIFF
--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from .models import DisasterEvent
+
+@admin.register(DisasterEvent)
+class DisasterEventAdmin(admin.ModelAdmin):
+    list_display = ('title', 'disaster_type', 'location', 'timestamp', 'severity')
+    search_fields = ('title', 'location', 'disaster_type')

--- a/backend/core/apiurls.py
+++ b/backend/core/apiurls.py
@@ -1,0 +1,14 @@
+# filepath: [urls.py](http://_vscodecontentref_/5)
+from django.urls import path
+from .views import (
+    DisasterEventListCreateView, DisasterEventDetailView,
+    SatelliteImageUploadView, TextSummarizeView, DisasterEventSearchView
+)
+
+urlpatterns = [
+    path('events/', DisasterEventListCreateView.as_view(), name='event-list-create'),
+    path('events/<int:pk>/', DisasterEventDetailView.as_view(), name='event-detail'),
+    path('upload-image/', SatelliteImageUploadView.as_view(), name='upload-image'),
+    path('summarize/', TextSummarizeView.as_view(), name='summarize-text'),
+    path('search/', DisasterEventSearchView.as_view(), name='event-search'),
+]

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -1,0 +1,18 @@
+from django.db import models
+
+class DisasterEvent(models.Model):
+    DISASTER_TYPES = [
+        ('flood', 'Flood'),
+        ('wildfire', 'Wildfire'),
+        ('earthquake', 'Earthquake'),
+        ('other', 'Other'),
+    ]
+    title = models.CharField(max_length=200)
+    disaster_type = models.CharField(max_length=20, choices=DISASTER_TYPES)
+    location = models.CharField(max_length=255)
+    latitude = models.FloatField()
+    longitude = models.FloatField()
+    timestamp = models.DateTimeField()
+    raw_data = models.JSONField()
+    summary = models.TextField(blank=True)
+    severity = models.FloatField(null=True, blank=True)

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import DisasterEvent
+
+class DisasterEventSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DisasterEvent
+        fields = '__all__'

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -37,6 +37,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
+    'core',
 ]
 
 MIDDLEWARE = [

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/', include('core.urls')),
 ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,0 +1,54 @@
+from rest_framework import generics, status
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from .models import DisasterEvent
+from .serializers import DisasterEventSerializer
+
+# Dummy AI functions (replace with real API calls as needed)
+def analyze_satellite_image(image_path):
+    # Simulate AI analysis
+    return {"flooded_area": 0.5, "burn_severity": 0.2}
+
+def summarize_text(text):
+    # Simulate AI summarization
+    return "AI-generated summary."
+
+class DisasterEventListCreateView(generics.ListCreateAPIView):
+    queryset = DisasterEvent.objects.all()
+    serializer_class = DisasterEventSerializer
+
+class DisasterEventDetailView(generics.RetrieveUpdateDestroyAPIView):
+    queryset = DisasterEvent.objects.all()
+    serializer_class = DisasterEventSerializer
+
+class SatelliteImageUploadView(APIView):
+    def post(self, request):
+        image = request.FILES.get('image')
+        if not image:
+            return Response({"error": "No image uploaded"}, status=400)
+        path = f"/tmp/{image.name}"
+        with open(path, "wb") as f:
+            for chunk in image.chunks():
+                f.write(chunk)
+        features = analyze_satellite_image(path)
+        return Response(features)
+
+class TextSummarizeView(APIView):
+    def post(self, request):
+        text = request.data.get("text")
+        if not text:
+            return Response({"error": "No text provided"}, status=400)
+        summary = summarize_text(text)
+        return Response({"summary": summary})
+
+class DisasterEventSearchView(APIView):
+    def get(self, request):
+        dtype = request.GET.get("type")
+        min_severity = float(request.GET.get("min_severity", 0))
+        queryset = DisasterEvent.objects.all()
+        if dtype:
+            queryset = queryset.filter(disaster_type=dtype)
+        if min_severity:
+            queryset = queryset.filter(severity__gte=min_severity)
+        serializer = DisasterEventSerializer(queryset, many=True)
+        return Response(serializer.data)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn
+pymongo
+python-dotenv
+requests
+google-cloud-vision
+google-cloud-aiplatform
+openai
+pillow
+scikit-learn

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,5 @@
-fastapi
-uvicorn
-pymongo
+django
+djangorestframework
 python-dotenv
 requests
 google-cloud-vision


### PR DESCRIPTION
Implement core DisasterSense backend with Django ORM, REST API, and AI endpoints

- Added DisasterEvent model for disaster records (with type, location, severity, summary, etc.)
- Implemented serializers for DisasterEvent
- Created API views for event CRUD, satellite image AI analysis, text summarization, and search/filter
- Configured API URLs for all endpoints
- Removed MongoDB dependencies; using default Django SQLite database
- Updated requirements.txt to reflect Django/DRF-only stack